### PR TITLE
Configure Zoho Auth Scopes

### DIFF
--- a/config/.env.example
+++ b/config/.env.example
@@ -9,6 +9,11 @@ ZOHO_REGION=US  # Options: US, EU, IN, AU, JP, CN, CA
 # ZOHO_API_BASE_URL=https://www.zohoapis.com/books/v3
 # ZOHO_AUTH_BASE_URL=https://accounts.zoho.com/oauth/v2
 
+# Comma separated list of OAuth scopes that will be requested 
+# See https://www.zoho.com/accounts/protocol/oauth/scope.html
+# for a full list of available scopes
+# ZOHO_OAUTH_SCOPE=ZohoBooks.fullaccess.all
+
 # Token Management - Optional
 # TOKEN_CACHE_PATH=/path/to/token/cache/file
 

--- a/zoho_mcp/auth_flow.py
+++ b/zoho_mcp/auth_flow.py
@@ -284,9 +284,10 @@ def run_oauth_flow(port: int = 8099) -> str:
         domain = settings.domain
         redirect_uri = f"http://localhost:{port}/callback"
         
+        scope = settings.ZOHO_OAUTH_SCOPE
         auth_url = (
             f"https://accounts.zoho.{domain}/oauth/v2/auth?"
-            f"scope=ZohoBooks.fullaccess.all&"
+            f"scope={scope}&"
             f"client_id={client_id}&"
             f"response_type=code&"
             f"access_type=offline&"

--- a/zoho_mcp/config/settings.py
+++ b/zoho_mcp/config/settings.py
@@ -60,6 +60,10 @@ class Settings:
     ZOHO_AUTH_BASE_URL: str = os.environ.get(
         "ZOHO_AUTH_BASE_URL", f"https://accounts.zoho.{domain}/oauth/v2"
     )
+    ZOHO_OAUTH_SCOPE: str = os.environ.get(
+        "ZOHO_OAUTH_SCOPE",
+        "ZohoBooks.fullaccess.all",
+    )
     
     # Token management
     TOKEN_CACHE_PATH: str = os.environ.get(


### PR DESCRIPTION
Fixes #1 - Allow the scopes that are requested during auth flow to be configured in the `.env` file. 
(Currently that was hardcoded to `ZohoBooks.fullaccess.all`)

See [.env.example](https://github.com/skvrahul/zoho-mcp/blob/ft/configure_oauth_scopes/config/.env.example) for more context